### PR TITLE
rotate for dendrogram with webkit for Safari

### DIFF
--- a/src/dendrogram/buildSingleDendroSlider.js
+++ b/src/dendrogram/buildSingleDendroSlider.js
@@ -109,7 +109,10 @@ export default function build_single_dendro_slider(regl, store, axis) {
   // add dendrogram level text
   // /////////////////////////////
   if (dendro.precalc_linkage) {
-    const text_transform = (axis == "row") ? "translate(0, 90) rotate(90)" : "translate(0, 90) rotate(90) scale(1, -1)"
+    const text_transform =
+      axis == "row"
+        ? "translate(0, 90) rotate(90)"
+        : "translate(0, 90) rotate(90) scale(1, -1)";
     slider_group
       .append("text")
       .classed("dendro_level_text", true)

--- a/src/ui/functions/buildDendrogramSliders.js
+++ b/src/ui/functions/buildDendrogramSliders.js
@@ -22,6 +22,11 @@ export default function build_dendrogram_sliders(regl, store) {
         if (inst_axis === "col") {
           return "rotate(-90) scale(-1,1)";
         }
+      })
+      .style("-webkit-transform", function () {
+        if (inst_axis === "col") {
+          return "rotate(-90deg) scale(-1,1)";
+        }
       });
     if (inst_axis === "row") {
       axis_slider_container.style("right", "-10px").style("top", "45px");


### PR DESCRIPTION
Solved the rotation problem of Dendrogram slider for x-axis in Safari browser, by implementing webkit transform to the style attribute. It resolves the issue mentioned at #30 

<img width="461" alt="Screen Shot 2022-09-30 at 14 34 17" src="https://user-images.githubusercontent.com/55454990/193261215-2742ee71-116e-42d8-8df3-0877280892b8.png">
