### PR TITLE
fix/reset on zoom and reorder

### DIFF
--- a/example/example-app/src/App.tsx
+++ b/example/example-app/src/App.tsx
@@ -19,7 +19,7 @@ const getArgs = (container: HTMLElement, data: any, otherProps: Partial<Clusterg
       show: true,
       height: "25%",
       side: "right",
-    }
+    },
     ...otherProps,
   }
 }

--- a/src/reorders/reorderMatrixArgs.ts
+++ b/src/reorders/reorderMatrixArgs.ts
@@ -22,4 +22,5 @@ export default (function reorderMatrixArgs(
       },
     },
   });
+  camerasManager.remakeMatrixArgs(store);
 });


### PR DESCRIPTION
This fixes #1 

It took a little while to figure our what is exactly going on. First thought that the state might be dirty on some point, but this wasn't the issue here. 

The solution was behind the opacity slider. When you start moving this one, after reordering, then everything works great. 

When we trigger the opacity slider, it is calling: `camerasManager.remakeMatrixArgs(store); `, which is what `reorderMatrixArgs.ts `was missing.

