### PR TITLE
Don't always return state and don't assign state object

### DIFF
--- a/src/state/reducers/animation/animationSlice.ts
+++ b/src/state/reducers/animation/animationSlice.ts
@@ -26,15 +26,13 @@ export const animationSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setAnimationState: (state, action: PayloadAction<AnimationState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateAnimationState: (
         state,
         action: PayloadAction<Partial<AnimationState>>
       ) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
     },
   });

--- a/src/state/reducers/arrsSlice.ts
+++ b/src/state/reducers/arrsSlice.ts
@@ -18,12 +18,10 @@ export const arrsSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setArrsState: (state, action: PayloadAction<ArrsState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateArrsState: (state, action: PayloadAction<Partial<ArrsState>>) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
     },
   });

--- a/src/state/reducers/catVizSlice.ts
+++ b/src/state/reducers/catVizSlice.ts
@@ -46,15 +46,13 @@ export const catVizSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setCatVizState: (state, action: PayloadAction<CatVizState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateCatVizState: (
         state,
         action: PayloadAction<Partial<CatVizState>>
       ) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
     },
   });

--- a/src/state/reducers/categoriesSlice.ts
+++ b/src/state/reducers/categoriesSlice.ts
@@ -38,15 +38,13 @@ export const categoriesSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setCategoriesState: (state, action: PayloadAction<CategoriesState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateCategoriesState: (
         state,
         action: PayloadAction<Partial<CategoriesState>>
       ) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
     },
   });

--- a/src/state/reducers/dendrogramSlice.ts
+++ b/src/state/reducers/dendrogramSlice.ts
@@ -51,15 +51,13 @@ export const dendrogramSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setDendrogramState: (state, action: PayloadAction<DendrogramState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateDendrogramState: (
         state,
         action: PayloadAction<Partial<DendrogramState>>
       ) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
     },
   });

--- a/src/state/reducers/downloadSlice.ts
+++ b/src/state/reducers/downloadSlice.ts
@@ -32,7 +32,6 @@ export const downloadSlice = (id: string) =>
         action: PayloadAction<DownloadState["delimiter_name"]>
       ) => {
         state.delimiter_name = action.payload;
-        return state;
       },
     },
   });

--- a/src/state/reducers/hzomeSlice.ts
+++ b/src/state/reducers/hzomeSlice.ts
@@ -22,7 +22,6 @@ export const hzomeSlice = (id: string) =>
     reducers: {
       mutateHzomeGeneData: (state, action: PayloadAction<HzomeState>) => {
         state.gene_data = merge(state.gene_data, action.payload);
-        return state;
       },
     },
   });

--- a/src/state/reducers/interaction/interactionSlice.ts
+++ b/src/state/reducers/interaction/interactionSlice.ts
@@ -32,26 +32,22 @@ export const interactionSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setInteractionState: (state, action: PayloadAction<InteractionState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateInteractionState: (
         state,
         action: PayloadAction<Partial<InteractionState>>
       ) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
       setMouseoverInteraction: (
         state,
         action: PayloadAction<InteractionState["mouseover"]>
       ) => {
         state.mouseover = action.payload;
-        return state;
       },
       incrementInteractionTotal: (state, action: PayloadAction<number>) => {
         state.total = state.total + action.payload;
-        return state;
       },
     },
   });

--- a/src/state/reducers/labels/labelsSlice.ts
+++ b/src/state/reducers/labels/labelsSlice.ts
@@ -67,29 +67,25 @@ export const labelsSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setLabelsState: (state, action: PayloadAction<LabelsState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateLabelsState: (
         state,
         action: PayloadAction<Partial<LabelsState>>
       ) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
       setLabelsOffsetDict: (
         state,
         action: PayloadAction<LabelsState["offset_dict"]>
       ) => {
         state.offset_dict = action.payload;
-        return state;
       },
       setLabelsQueue: (
         state,
         action: PayloadAction<LabelsState["labels_queue"]>
       ) => {
         state.labels_queue = action.payload;
-        return state;
       },
       pushHighQueueLabel: (
         state,

--- a/src/state/reducers/matrixSlice.ts
+++ b/src/state/reducers/matrixSlice.ts
@@ -30,22 +30,19 @@ export const matrixSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setMatrixState: (state, action: PayloadAction<MatrixState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateMatrixState: (
         state,
         action: PayloadAction<Partial<MatrixState>>
       ) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
       setOpacityScale: (
         state,
         action: PayloadAction<MatrixState["opacity_scale"]>
       ) => {
         state.opacity_scale = action.payload;
-        return state;
       },
     },
   });

--- a/src/state/reducers/networkSlice.ts
+++ b/src/state/reducers/networkSlice.ts
@@ -50,15 +50,13 @@ export const networkSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setNetworkState: (state, action: PayloadAction<NetworkState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateNetworkState: (
         state,
         action: PayloadAction<Partial<NetworkState>>
       ) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
     },
   });

--- a/src/state/reducers/nodeCanvasPosSlice.ts
+++ b/src/state/reducers/nodeCanvasPosSlice.ts
@@ -14,8 +14,7 @@ export const nodeCanvasPosSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setNodeCanvasPos: (state, action: PayloadAction<NodeCanvasPos>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
     },
   });

--- a/src/state/reducers/order/orderSlice.ts
+++ b/src/state/reducers/order/orderSlice.ts
@@ -22,12 +22,10 @@ export const orderSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setOrderState: (state, action: PayloadAction<OrderState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateOrderState: (state, action: PayloadAction<Partial<OrderState>>) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
     },
   });

--- a/src/state/reducers/rowAndColCanvasPositionsSlice.ts
+++ b/src/state/reducers/rowAndColCanvasPositionsSlice.ts
@@ -17,8 +17,7 @@ export const rowAndColCanvasPositionsSlice = (id: string) =>
         state,
         action: PayloadAction<RowAndColCanvasPositions>
       ) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
     },
   });

--- a/src/state/reducers/searchSlice.ts
+++ b/src/state/reducers/searchSlice.ts
@@ -23,7 +23,6 @@ export const searchSlice = (id: string) =>
         action: PayloadAction<SearchState["searched_rows"]>
       ) => {
         state.searched_rows = action.payload;
-        return state;
       },
       setHightlightedRowsAndCols: (
         state,
@@ -34,21 +33,18 @@ export const searchSlice = (id: string) =>
       ) => {
         state.highlighted_rows = action.payload.hightlighted_rows;
         state.highlighted_cols = action.payload.highlighted_cols;
-        return state;
       },
       setHighlightedRows: (
         state,
         action: PayloadAction<SearchState["highlighted_rows"]>
       ) => {
         state.highlighted_rows = action.payload;
-        return state;
       },
       setHighlightedCols: (
         state,
         action: PayloadAction<SearchState["highlighted_cols"]>
       ) => {
         state.highlighted_cols = action.payload;
-        return state;
       }
     },
   });

--- a/src/state/reducers/tooltip/tooltipSlice.ts
+++ b/src/state/reducers/tooltip/tooltipSlice.ts
@@ -33,15 +33,13 @@ export const tooltipSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setTooltipState: (state, action: PayloadAction<TooltipState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateTooltipState: (
         state,
         action: PayloadAction<Partial<TooltipState>>
       ) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
     },
   });

--- a/src/state/reducers/uiSlice.ts
+++ b/src/state/reducers/uiSlice.ts
@@ -11,8 +11,7 @@ export const uiSlice = (id: string) =>
     // The `reducers` field lets us define reducers and generate associated actions
     reducers: {
       setUI: (state, action: PayloadAction<UIState>) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
     },
   });

--- a/src/state/reducers/visualization/visualizationSlice.ts
+++ b/src/state/reducers/visualization/visualizationSlice.ts
@@ -149,40 +149,34 @@ export const visualizationSlice = (id: string) =>
         state,
         action: PayloadAction<VisualizationState>
       ) => {
-        state = action.payload;
-        return state;
+        return action.payload;
       },
       mutateVisualizationState: (
         state,
         action: PayloadAction<Partial<VisualizationState>>
       ) => {
-        state = merge(state, action.payload);
-        return state;
+        return merge(state, action.payload);
       },
       mutateZoomData: (
         state,
         action: PayloadAction<Partial<VisualizationState["zoom_data"]>>
       ) => {
         state.zoom_data = merge(state.zoom_data, action.payload);
-        return state;
       },
       setZoomData: (
         state,
         action: PayloadAction<VisualizationState["zoom_data"]>
       ) => {
         state.zoom_data = action.payload;
-        return state;
       },
       setVisualizationDimensions: (
         state,
         action: PayloadAction<VisualizationState["viz_dim"]>
       ) => {
         state.viz_dim = action.payload;
-        return state;
       },
       setTotalMouseover: (state, action: PayloadAction<number>) => {
         state.total_mouseover = action.payload;
-        return state;
       },
     },
   });


### PR DESCRIPTION
This is removing any `state = *` assignments and unnecessary `return state`. Part of #37 

The reducer/s will take the state without state being manually assigned. The `return` is only needed, if we actually want to replace the entire state (e.g. state = action.props or state = merge(x, y))